### PR TITLE
Enable interactive extraction editing and hotkeys

### DIFF
--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -155,6 +155,26 @@ class VisualizationTest(absltest.TestCase):
 
     self.assertEqual(actual_html, expected_html)
 
+  @mock.patch.object(
+      visualization, "HTML", new=None
+  )  # Ensures visualize returns str
+  def test_visualize_includes_hotkeys_mapping(self):
+
+    doc = lx_data.AnnotatedDocument(
+        text="Sample text",
+        extractions=[
+            lx_data.Extraction(
+                extraction_class="MED",
+                extraction_text="Sample",
+                char_interval=lx_data.CharInterval(start_pos=0, end_pos=6),
+            )
+        ],
+    )
+
+    html_output = visualization.visualize(doc, class_hotkeys={"m": "MED"})
+
+    self.assertIn('const classHotkeys = {"m": "MED"}', html_output)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Summary
- Allow users to modify `extraction_text` directly in the visualization by selecting text within the document
- Add customizable hotkey support for quickly reassigning an extraction's class
- Cover hotkey mapping with unit tests

## Testing
- `pre-commit run --files langextract/visualization.py tests/visualization_test.py`
- `pytest tests/visualization_test.py`
- `pytest` *(fails: ModuleNotFoundError for openai provider tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cae748f14833092cd3de5adfa61a2