### PR TITLE
feat: switch example plugin to llama.cpp API

### DIFF
--- a/examples/custom_provider_plugin/README.md
+++ b/examples/custom_provider_plugin/README.md
@@ -9,8 +9,8 @@ This example demonstrates how to create a custom provider plugin that extends La
 ```
 custom_provider_plugin/
 ├── pyproject.toml                      # Package configuration and metadata
-├── README.md                            # This file
-├── langextract_provider_example/        # Package directory
+├── README.md                           # This file
+├── langextract_provider_example/       # Package directory
 │   ├── __init__.py                     # Package initialization
 │   ├── provider.py                     # Custom provider implementation
 │   └── schema.py                       # Custom schema implementation (optional)
@@ -23,9 +23,9 @@ custom_provider_plugin/
 
 ```python
 @lx.providers.registry.register(
-    r'^gemini',  # Pattern for model IDs this provider handles
+    r'^llama',  # Pattern for model IDs this provider handles
 )
-class CustomGeminiProvider(lx.inference.BaseLanguageModel):
+class CustomLlamaCppProvider(lx.inference.BaseLanguageModel):
     def __init__(self, model_id: str, **kwargs):
         # Initialize your backend client
 
@@ -37,7 +37,7 @@ class CustomGeminiProvider(lx.inference.BaseLanguageModel):
 
 ```toml
 [project.entry-points."langextract.providers"]
-custom_gemini = "langextract_provider_example:CustomGeminiProvider"
+custom_llama_cpp = "langextract_provider_example:CustomLlamaCppProvider"
 ```
 
 This entry point allows LangExtract to automatically discover your provider.
@@ -102,16 +102,16 @@ python test_example_provider.py
 
 ## Usage
 
-Since this example registers the same pattern as the default Gemini provider, you must explicitly specify it:
+Since this example registers the same pattern as a default provider, you must explicitly specify it:
 
 ```python
 import langextract as lx
 
 # Create a configured model with explicit provider selection
 config = lx.factory.ModelConfig(
-    model_id="gemini-2.5-flash",
-    provider="CustomGeminiProvider",
-    provider_kwargs={"api_key": "your-api-key"}
+    model_id="llama",  # or leave None to use the first model from the server
+    provider="CustomLlamaCppProvider",
+    provider_kwargs={"api_base": "http://127.0.0.1:8080"},
 )
 model = lx.factory.create_model(config)
 
@@ -119,17 +119,16 @@ model = lx.factory.create_model(config)
 # For now, use the model's infer() method directly or pass parameters individually:
 result = lx.extract(
     text_or_documents="Your text here",
-    model_id="gemini-2.5-flash",
-    api_key="your-api-key",
+    model_id="llama",
     prompt_description="Extract key information",
-    examples=[...]
+    examples=[...],
 )
 
 # Coming soon: Direct model passing
 # result = lx.extract(
 #     text_or_documents="Your text here",
 #     model=model,  # Planned feature
-#     prompt_description="Extract key information"
+#     prompt_description="Extract key information",
 # )
 ```
 
@@ -137,7 +136,7 @@ result = lx.extract(
 
 1. Copy this example as a starting point
 2. Update the provider class name and registration pattern
-3. Replace the Gemini implementation with your own backend
+3. Replace the example implementation with your own backend
 4. Update package name in `pyproject.toml`
 5. Install and test your plugin
 

--- a/examples/custom_provider_plugin/langextract_provider_example/__init__.py
+++ b/examples/custom_provider_plugin/langextract_provider_example/__init__.py
@@ -14,7 +14,7 @@
 
 """Example custom provider plugin for LangExtract."""
 
-from langextract_provider_example.provider import CustomGeminiProvider
+from langextract_provider_example.provider import CustomLlamaCppProvider
 
-__all__ = ["CustomGeminiProvider"]
+__all__ = ["CustomLlamaCppProvider"]
 __version__ = "0.1.0"

--- a/examples/custom_provider_plugin/langextract_provider_example/schema.py
+++ b/examples/custom_provider_plugin/langextract_provider_example/schema.py
@@ -33,7 +33,8 @@ class CustomProviderSchema(lx.schema.BaseSchema):
   3. Optimize for their specific model capabilities
 
   This example generates a JSON schema from the examples and passes it to
-  the Gemini backend (which this example provider wraps) for structured output.
+  the llama.cpp backend (which this example provider wraps) for structured
+  output.
   """
 
   def __init__(self, schema_dict: dict[str, Any], strict_mode: bool = True):

--- a/examples/custom_provider_plugin/pyproject.toml
+++ b/examples/custom_provider_plugin/pyproject.toml
@@ -26,12 +26,12 @@ license = {text = "Apache-2.0"}
 dependencies = [
     # Uncomment when creating a standalone plugin package:
     # "langextract",  # Will install latest version
-    "google-genai>=0.2.0",  # Replace with your backend's SDK
+    "openai",  # Replace with your backend's SDK
 ]
 
 # Register the provider with LangExtract's plugin system
 [project.entry-points."langextract.providers"]
-custom_gemini = "langextract_provider_example:CustomGeminiProvider"
+custom_llama_cpp = "langextract_provider_example:CustomLlamaCppProvider"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/examples/custom_provider_plugin/test_example_provider.py
+++ b/examples/custom_provider_plugin/test_example_provider.py
@@ -20,23 +20,19 @@ import os
 # Import the provider to trigger registration with LangExtract
 # Note: This manual import is only needed when running without installation.
 # After `pip install -e .`, the entry point system handles this automatically.
-from langextract_provider_example import CustomGeminiProvider  # noqa: F401
+from langextract_provider_example import CustomLlamaCppProvider  # noqa: F401
 
 import langextract as lx
 
 
 def main():
   """Test the custom provider."""
-  api_key = os.getenv("GEMINI_API_KEY") or os.getenv("LANGEXTRACT_API_KEY")
-
-  if not api_key:
-    print("Set GEMINI_API_KEY or LANGEXTRACT_API_KEY to test")
-    return
+  api_base = os.getenv("LLAMACPP_API_BASE", "http://127.0.0.1:8080")
 
   config = lx.factory.ModelConfig(
-      model_id="gemini-2.5-flash",
-      provider="CustomGeminiProvider",
-      provider_kwargs={"api_key": api_key},
+      model_id="llama",
+      provider="CustomLlamaCppProvider",
+      provider_kwargs={"api_base": api_base},
   )
   model = lx.factory.create_model(config)
 


### PR DESCRIPTION
## Summary
- replace Gemini example provider with OpenAI-compatible llama.cpp client
- update plugin docs and entry points for new provider
- add test script using local llama.cpp server

## Testing
- `python -m isort examples/custom_provider_plugin`
- `python -m pyink examples/custom_provider_plugin`
- `python -m pre_commit run --files examples/custom_provider_plugin/README.md examples/custom_provider_plugin/pyproject.toml examples/custom_provider_plugin/test_example_provider.py examples/custom_provider_plugin/langextract_provider_example/provider.py examples/custom_provider_plugin/langextract_provider_example/__init__.py examples/custom_provider_plugin/langextract_provider_example/schema.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'langextract')*


------
https://chatgpt.com/codex/tasks/task_e_689e3d779ce4833080aec89fb7fc6413