### PR TITLE
Support OpenAI-style JSON schema in LlamaCpp provider

### DIFF
--- a/langextract-llamacpp/langextract_llamacpp/provider.py
+++ b/langextract-llamacpp/langextract_llamacpp/provider.py
@@ -38,6 +38,7 @@ class LlamaCppLanguageModel(lx.inference.BaseLanguageModel):
     )
     self.response_schema = kwargs.get("response_schema")
     self.structured_output = kwargs.get("structured_output", False)
+    self.response_format = kwargs.get("response_format")
 
     self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
     self._extra_kwargs = kwargs
@@ -56,9 +57,20 @@ class LlamaCppLanguageModel(lx.inference.BaseLanguageModel):
       config = schema_instance.to_provider_config()
       self.response_schema = config.get("response_schema")
       self.structured_output = config.get("structured_output", False)
+      if self.structured_output and self.response_schema:
+        self.response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "langextract_schema",
+                "schema": self.response_schema,
+            },
+        }
+      else:
+        self.response_format = None
     else:
       self.response_schema = None
       self.structured_output = False
+      self.response_format = None
 
   def infer(self, batch_prompts, **kwargs):
     """Run inference on a batch of prompts.
@@ -75,7 +87,9 @@ class LlamaCppLanguageModel(lx.inference.BaseLanguageModel):
           "model": self.model_id,
           "messages": [{"role": "user", "content": prompt}],
       }
-      if self.response_schema:
+      if self.response_format:
+        api_params["response_format"] = self.response_format
+      elif self.response_schema:
         api_params["response_schema"] = self.response_schema
       api_params.update(kwargs)
       response = self.client.chat.completions.create(**api_params)

--- a/tests/llamacpp_provider_test.py
+++ b/tests/llamacpp_provider_test.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+from absl.testing import absltest
+from langextract_llamacpp.provider import LlamaCppLanguageModel
+from langextract_llamacpp.schema import LlamaCppSchema
+
+
+class LlamaCppProviderTest(absltest.TestCase):
+
+  @mock.patch("langextract_llamacpp.provider.OpenAI")
+  def test_structured_output_response_format(self, mock_openai_class):
+    mock_client = mock.Mock()
+    mock_openai_class.return_value = mock_client
+
+    mock_response = mock.Mock()
+    mock_response.choices = [mock.Mock(message=mock.Mock(content="{}"))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    schema_dict = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    schema = LlamaCppSchema(schema_dict)
+
+    model = LlamaCppLanguageModel(model_id="llama-test")
+    model.apply_schema(schema)
+
+    list(model.infer(["test prompt"]))
+
+    mock_client.chat.completions.create.assert_called_once()
+    call_args = mock_client.chat.completions.create.call_args
+    self.assertEqual(
+        call_args.kwargs["response_format"],
+        {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "langextract_schema",
+                "schema": schema_dict,
+            },
+        },
+    )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary
- build OpenAI-compatible `response_format` when applying structured schemas in the LlamaCpp provider
- send `response_format` on inference requests
- add unit test for structured output handling

## Testing
- `python -m pre_commit run --files langextract-llamacpp/langextract_llamacpp/provider.py tests/llamacpp_provider_test.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31d554ed08330bd272cd828920bed