### PR TITLE
Expand LlamaCpp provider regex

### DIFF
--- a/langextract-llamacpp/langextract_llamacpp/provider.py
+++ b/langextract-llamacpp/langextract_llamacpp/provider.py
@@ -8,11 +8,11 @@ from openai import OpenAI
 import langextract as lx
 
 
-@lx.providers.registry.register(r"^llama", priority=10)
+@lx.providers.registry.register(r"^(llama|qwen|.*gguf$)", priority=10)
 class LlamaCppLanguageModel(lx.inference.BaseLanguageModel):
   """LangExtract provider for LlamaCpp.
 
-  This provider handles model IDs matching: ['^llama']
+  This provider handles model IDs matching: ['^(llama|qwen|.*gguf$)']
   """
 
   def __init__(


### PR DESCRIPTION
## Summary
- broaden LlamaCpp provider registration regex to support more model IDs, including qwen and gguf models

## Testing
- `bash autoformat.sh` *(fails: pyink not found)*
- `python -m isort langextract-llamacpp/langextract_llamacpp/provider.py`
- `python -m pyink langextract-llamacpp/langextract_llamacpp/provider.py`
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31d66eb188330944b74398b3a8c92